### PR TITLE
CI: Update apt cache

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -5,6 +5,18 @@ runs:
   steps:
   - shell: bash
     run: |
+      echo "OS_NAME=$(grep '^ID=' /etc/os-release)" >> $GITHUB_ENV
+
+  # Ensure updated apt cache. This avoids errors such as
+  # Failed to fetch
+  # http://azure.archive.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-dbg_2.31-0ubuntu9.2_amd64.deb
+  # 404  Not Found...
+  - shell: bash
+    if: contains(env.OS_NAME, 'ubuntu')
+    run: sudo apt-get update
+
+  - shell: bash
+    run: |
       cd contrib/ci/
       . deps.sh
       deps_install


### PR DESCRIPTION
Fixes error on runners in GH Action workflows when installing packages

Fetched 46.1 MB in 13s (3596 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-dbg_2.31-0ubuntu9.2_amd64.deb
404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?