### PR TITLE
SSSCTL: Fix covscan issue

### DIFF
--- a/src/tools/sssctl/sssctl_logs.c
+++ b/src/tools/sssctl/sssctl_logs.c
@@ -397,7 +397,7 @@ errno_t sssctl_analyze(struct sss_cmdline *cmdline,
 #ifndef BUILD_CHAIN_ID
     PRINT("ERROR: Tevent chain ID support missing, log analyzer is unsupported.\n");
     return EOK;
-#endif
+#else
     errno_t ret;
 
     const char **args = talloc_array_size(tool_ctx,
@@ -415,4 +415,5 @@ errno_t sssctl_analyze(struct sss_cmdline *cmdline,
     talloc_free(args);
 
     return ret;
+#endif
 }


### PR DESCRIPTION
*** CID 350352:  Control flow issues  (UNREACHABLE)
/home/runner/work/sssd/sssd/src/tools/sssctl/sssctl_logs.c: 401 in sssctl_analyze()
395                            void *pvt)
396     {
397     #ifndef BUILD_CHAIN_ID
398         PRINT("ERROR: Tevent chain ID support missing, log analyzer is unsupported.\n");
399         return EOK;
400     #endif
>>>     CID 350352:  Control flow issues  (UNREACHABLE)
>>>     This code cannot be reached: "errno_t ret;".
401         errno_t ret;
402
403         const char **args = talloc_array_size(tool_ctx,
404                                               sizeof(char *),
405                                               cmdline->argc + 2);
406         if (!args) {