### PR TITLE
CI: Build srpm fix for illegal char '-'

### DIFF
--- a/.github/actions/build-sssd-srpm/action.yml
+++ b/.github/actions/build-sssd-srpm/action.yml
@@ -25,7 +25,7 @@ runs:
     shell: bash
     run: |
       pushd '${{ inputs.working-directory }}'
-      version="${{ inputs.version }}"
+      version="echo ${{ inputs.version }} | sed 's/-/_/g'"
       release="${{ inputs.release }}"
       name="sssd-$version"
       tar -cvzf "$name.tar.gz" --transform "s,^,$name/," *


### PR DESCRIPTION
error: line 45: Illegal char '-' (0x2d) in: Version: sssd-2-7